### PR TITLE
fix: update empty task message to 'No Tasks...'

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -70,7 +70,7 @@ export default async function Dashboard(props: { searchParams: Promise<{ filter?
               <div className="hero py-10 bg-base-200 rounded-box">
                 <div className="hero-content text-center">
                   <div className="max-w-md opacity-50">
-                    <h1 className="text-2xl font-bold">All caught up</h1>
+                    <h1 className="text-2xl font-bold">No Tasks...</h1>
                   </div>
                 </div>
               </div>


### PR DESCRIPTION
This pull request makes a small change to the empty state message on the dashboard. The message shown when there are no tasks has been updated for clarity. 

* Changed the empty state heading from "All caught up" to "No Tasks..." in the dashboard (`app/page.tsx`).