### PR TITLE
fix: update no tasks message to 'All caught up'

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -70,7 +70,7 @@ export default async function Dashboard(props: { searchParams: Promise<{ filter?
               <div className="hero py-10 bg-base-200 rounded-box">
                 <div className="hero-content text-center">
                   <div className="max-w-md opacity-50">
-                    <h1 className="text-2xl font-bold">No Tasks...</h1>
+                    <h1 className="text-2xl font-bold">All caught up</h1>
                   </div>
                 </div>
               </div>


### PR DESCRIPTION
This pull request makes a minor user interface improvement by updating the message shown when there are no tasks on the dashboard.

* Changed the empty state heading from "No Tasks..." to "All caught up" in the dashboard page for a more positive user experience.