### PR TITLE
feat: add floating theme toggle component for color scheme switching.

### DIFF
--- a/src/components/FloatingThemeToggle.tsx
+++ b/src/components/FloatingThemeToggle.tsx
@@ -2,9 +2,23 @@
 
 import { ActionIcon, useMantineColorScheme, Group } from '@mantine/core';
 import { IconSun, IconMoon } from '@tabler/icons-react';
+import { useEffect, useState } from 'react';
 
 export function FloatingThemeToggle() {
     const { colorScheme, toggleColorScheme } = useMantineColorScheme();
+    const [mounted, setMounted] = useState(false);
+
+    useEffect(() => {
+        setMounted(true);
+    }, []);
+
+    if (!mounted) {
+        return (
+            <Group pos="fixed" bottom={20} left={20} style={{ zIndex: 1000 }}>
+                <ActionIcon size="lg" radius="xl" variant="default" aria-label="Toggle color scheme" />
+            </Group>
+        );
+    }
 
     return (
         <Group pos="fixed" bottom={20} left={20} style={{ zIndex: 1000 }}>


### PR DESCRIPTION
This pull request improves the user experience of the `FloatingThemeToggle` component by ensuring it only renders the toggle button after the component has mounted, which helps prevent issues related to mismatched server and client rendering.

Rendering and mounting improvements:

* Added a `mounted` state and a `useEffect` hook to delay rendering the interactive toggle button until after the component has mounted, avoiding hydration mismatches.
* Renders a placeholder button before mounting to maintain layout consistency.