### PR TITLE
feat: Implement recipe editing and deletion functionality with reposi…

### DIFF
--- a/src/components/recipes/RecipeComponents.tsx
+++ b/src/components/recipes/RecipeComponents.tsx
@@ -11,13 +11,35 @@ interface RecipeDetailModalProps {
     recipe: ProcessedRecipe | null;
     opened: boolean;
     onClose: () => void;
+    onEdit?: (recipe: ProcessedRecipe) => void;
 }
 
-export function RecipeDetailModal({ recipe, opened, onClose }: RecipeDetailModalProps) {
+export function RecipeDetailModal({ recipe, opened, onClose, onEdit }: RecipeDetailModalProps) {
     if (!recipe) return null;
 
     return (
-        <Modal opened={opened} onClose={onClose} title={<Text fw={700} size="lg">{recipe.title}</Text>} size="lg" centered>
+        <Modal
+            opened={opened}
+            onClose={onClose}
+            title={
+                <Group>
+                    <Text fw={700} size="lg">{recipe.title}</Text>
+                    {onEdit && (
+                        <Button
+                            variant="light"
+                            color="blue"
+                            size="xs"
+                            leftSection={<IconTools size={14} />}
+                            onClick={() => onEdit(recipe)}
+                        >
+                            Edit Recipe
+                        </Button>
+                    )}
+                </Group>
+            }
+            size="lg"
+            centered
+        >
             <Stack gap="md">
                 {/* Header Stats */}
                 <Group justify="space-between" bg="gray.1" p="sm" style={{ borderRadius: 8 }}>


### PR DESCRIPTION
This pull request introduces full recipe editing capabilities to the Recipes feature, allowing users to update and delete existing recipes in addition to creating new ones. It refactors the recipe form for dual create/edit functionality, adds user feedback via notifications, and improves the workflow for switching between create and edit modes. The backend logic is also updated to support recipe updates. 

**Recipe Editing and Deletion Functionality**
- Refactored the recipe creation form into a unified `RecipeForm` component that supports both creating new recipes and editing existing ones, including the ability to delete recipes directly from the form. The form now resets appropriately when switching between modes. [[1]](diffhunk://#diff-2d34df26a56c7579f04ed49090e0e71754d7ee8583e3726d75a5406473e7d5e8L43-R72) [[2]](diffhunk://#diff-2d34df26a56c7579f04ed49090e0e71754d7ee8583e3726d75a5406473e7d5e8L68-R112) [[3]](diffhunk://#diff-2d34df26a56c7579f04ed49090e0e71754d7ee8583e3726d75a5406473e7d5e8R132-L93) [[4]](diffhunk://#diff-2d34df26a56c7579f04ed49090e0e71754d7ee8583e3726d75a5406473e7d5e8R154-R184) [[5]](diffhunk://#diff-2d34df26a56c7579f04ed49090e0e71754d7ee8583e3726d75a5406473e7d5e8L135-R208) [[6]](diffhunk://#diff-2d34df26a56c7579f04ed49090e0e71754d7ee8583e3726d75a5406473e7d5e8L224-R295)
- Added a delete button to the form in edit mode, which confirms with the user before deleting the recipe. [[1]](diffhunk://#diff-2d34df26a56c7579f04ed49090e0e71754d7ee8583e3726d75a5406473e7d5e8R132-L93) [[2]](diffhunk://#diff-2d34df26a56c7579f04ed49090e0e71754d7ee8583e3726d75a5406473e7d5e8L135-R208) [[3]](diffhunk://#diff-2d34df26a56c7579f04ed49090e0e71754d7ee8583e3726d75a5406473e7d5e8L224-R295)

**User Experience Improvements**
- Replaced in-form alerts with global notifications for success and error feedback, using Mantine's notifications system and appropriate icons. [[1]](diffhunk://#diff-2d34df26a56c7579f04ed49090e0e71754d7ee8583e3726d75a5406473e7d5e8L26-R27) [[2]](diffhunk://#diff-2d34df26a56c7579f04ed49090e0e71754d7ee8583e3726d75a5406473e7d5e8R154-R184)
- Added cancel functionality to the form, allowing users to exit editing or creation mode without saving. [[1]](diffhunk://#diff-2d34df26a56c7579f04ed49090e0e71754d7ee8583e3726d75a5406473e7d5e8L224-R295) [[2]](diffhunk://#diff-2d34df26a56c7579f04ed49090e0e71754d7ee8583e3726d75a5406473e7d5e8R313-R318)

**Workflow and State Management Enhancements**
- Introduced state management for editing (`editingRecipe`), ensuring smooth transitions between create and edit modes, including correct tab and form session handling. [[1]](diffhunk://#diff-2d34df26a56c7579f04ed49090e0e71754d7ee8583e3726d75a5406473e7d5e8R313-R318) [[2]](diffhunk://#diff-2d34df26a56c7579f04ed49090e0e71754d7ee8583e3726d75a5406473e7d5e8R339-R342) [[3]](diffhunk://#diff-2d34df26a56c7579f04ed49090e0e71754d7ee8583e3726d75a5406473e7d5e8R351-R371) [[4]](diffhunk://#diff-2d34df26a56c7579f04ed49090e0e71754d7ee8583e3726d75a5406473e7d5e8L284-R384) [[5]](diffhunk://#diff-2d34df26a56c7579f04ed49090e0e71754d7ee8583e3726d75a5406473e7d5e8L293-R394) [[6]](diffhunk://#diff-2d34df26a56c7579f04ed49090e0e71754d7ee8583e3726d75a5406473e7d5e8L334-R451)
- Updated the recipe detail modal to include an "Edit Recipe" button, which opens the selected recipe in edit mode. [[1]](diffhunk://#diff-ae99206a4fef58f5a2264fa22e0c236c222dc1f70e3dd3d65b696421c3abbf9aR14-R42) [[2]](diffhunk://#diff-2d34df26a56c7579f04ed49090e0e71754d7ee8583e3726d75a5406473e7d5e8R470)

**Backend Support**
- Added a new `updateRecipe` function in the repository layer to handle updating recipe details and associated ingredients in the database, including full ingredient reconciliation.

These changes collectively provide a seamless and robust experience for managing recipes, supporting full CRUD operations and improving usability throughout the workflow.