### PR TITLE
feat: Centralize app navigation and dashboard card data into a new `n…

### DIFF
--- a/src/app/app/page.tsx
+++ b/src/app/app/page.tsx
@@ -1,5 +1,5 @@
 import { Container, Title, SimpleGrid } from '@mantine/core';
-import { IconListCheck, IconChefHat, IconNotebook, IconTrophy } from '@tabler/icons-react';
+import { NAV_LINKS } from '@/config/navLinks';
 import { createClient } from '@/lib/supabase/server';
 import { DashboardCard } from './DashboardCard';
 
@@ -14,34 +14,18 @@ export default async function DashboardPage() {
             </Title>
 
             <SimpleGrid cols={{ base: 1, sm: 2 }} spacing="lg">
-                <DashboardCard
-                    title="My Tasks"
-                    description="View and manage your todo list."
-                    icon={<IconListCheck size={24} />}
-                    href="/app/tasks"
-                    color="blue"
-                />
-                <DashboardCard
-                    title="Recipes"
-                    description="Plan your meals and nutrition."
-                    icon={<IconChefHat size={24} />}
-                    href="/app/recipes"
-                    color="green"
-                />
-                <DashboardCard
-                    title="Daily Notes"
-                    description="Capture thoughts and history."
-                    icon={<IconNotebook size={24} />}
-                    href="/app/notes"
-                    color="orange"
-                />
-                <DashboardCard
-                    title="Achievements"
-                    description="Visualize your progress."
-                    icon={<IconTrophy size={24} />}
-                    href="/app/achievements"
-                    color="yellow"
-                />
+                {NAV_LINKS
+                    .filter(link => link.label !== 'Dashboard' && link.label !== 'Settings')
+                    .map((link) => (
+                        <DashboardCard
+                            key={link.label}
+                            title={link.label}
+                            description={link.description || ''}
+                            icon={<link.icon size={24} />}
+                            href={link.href}
+                            color={link.color || 'blue'}
+                        />
+                    ))}
             </SimpleGrid>
         </Container>
     );

--- a/src/components/AppLayout.tsx
+++ b/src/components/AppLayout.tsx
@@ -2,23 +2,17 @@
 
 import { AppShell, Burger, Group, NavLink, Text, ThemeIcon, ScrollArea, Divider, Button } from '@mantine/core';
 import { useDisclosure } from '@mantine/hooks';
-import { IconHome, IconListCheck, IconChefHat, IconSettings, IconNotebook, IconTrophy, IconCalendarWeek, IconCurrencyDollar } from '@tabler/icons-react';
+import { IconHome, IconSettings } from '@tabler/icons-react';
 import Link from 'next/link';
 import { usePathname } from 'next/navigation';
+
+import { NAV_LINKS } from '@/config/navLinks';
 
 export function AppLayout({ children }: { children: React.ReactNode }) {
     const [opened, { toggle }] = useDisclosure();
     const pathname = usePathname();
 
-    const links = [
-        { icon: IconHome, label: 'Dashboard', href: '/app' },
-        { icon: IconListCheck, label: 'Tasks', href: '/app/tasks' },
-        { icon: IconCalendarWeek, label: 'Weekly Planner', href: '/app/planner' },
-        { icon: IconChefHat, label: 'Recipes', href: '/app/recipes' },
-        { icon: IconNotebook, label: 'Notes', href: '/app/notes' },
-        { icon: IconTrophy, label: 'Achievements', href: '/app/achievements' },
-        { icon: IconCurrencyDollar, label: 'Finance', href: '/app/finance' },
-    ];
+    const links = NAV_LINKS.filter(link => link.label !== 'Settings');
 
     const items = links.map((link) => (
         <NavLink
@@ -40,7 +34,7 @@ export function AppLayout({ children }: { children: React.ReactNode }) {
         <AppShell
             header={{ height: 60 }}
             navbar={{
-                width: 200,
+                width: { base: 300, md: 200 },
                 breakpoint: 'md',
                 collapsed: { mobile: !opened },
             }}
@@ -48,7 +42,7 @@ export function AppLayout({ children }: { children: React.ReactNode }) {
         >
             <AppShell.Header>
                 <Group h="100%" px="xs">
-                    <Burger opened={opened} onClick={toggle} hiddenFrom="md" size="sm" />
+                    <Burger opened={opened} onClick={toggle} hiddenFrom="md" size="md" />
                     <Link href="/app" style={{ textDecoration: 'none', color: 'inherit' }}>
                         <Group gap="xs">
                             <ThemeIcon variant="filled" size="md">

--- a/src/config/navLinks.tsx
+++ b/src/config/navLinks.tsx
@@ -1,0 +1,77 @@
+import {
+    IconHome,
+    IconListCheck,
+    IconCalendarWeek,
+    IconChefHat,
+    IconNotebook,
+    IconTrophy,
+    IconCurrencyDollar,
+    IconSettings,
+} from '@tabler/icons-react';
+
+export interface NavLink {
+    label: string;
+    icon: any; // Using any for icon component type for simplicity with Tabler icons
+    href: string;
+    description?: string;
+    color?: string; // Mantine color for dashboard cards
+}
+
+export const NAV_LINKS: NavLink[] = [
+    {
+        label: 'Dashboard',
+        icon: IconHome,
+        href: '/app',
+        description: 'Overview of your personal OS.',
+        color: 'blue',
+    },
+    {
+        label: 'Tasks',
+        icon: IconListCheck,
+        href: '/app/tasks',
+        description: 'View and manage your todo list.',
+        color: 'blue',
+    },
+    {
+        label: 'Weekly Planner',
+        icon: IconCalendarWeek,
+        href: '/app/planner',
+        description: 'Plan your week ahead.',
+        color: 'violet',
+    },
+    {
+        label: 'Recipes',
+        icon: IconChefHat,
+        href: '/app/recipes',
+        description: 'Plan your meals and nutrition.',
+        color: 'green',
+    },
+    {
+        label: 'Notes',
+        icon: IconNotebook,
+        href: '/app/notes',
+        description: 'Capture thoughts and history.',
+        color: 'orange',
+    },
+    {
+        label: 'Achievements',
+        icon: IconTrophy,
+        href: '/app/achievements',
+        description: 'Visualize your progress.',
+        color: 'yellow',
+    },
+    {
+        label: 'Finance',
+        icon: IconCurrencyDollar,
+        href: '/app/finance',
+        description: 'Track your expenses and budget.',
+        color: 'teal',
+    },
+    {
+        label: 'Settings',
+        icon: IconSettings,
+        href: '/app/settings',
+        description: 'Configure your application.',
+        color: 'gray',
+    },
+];


### PR DESCRIPTION
This pull request refactors the navigation and dashboard card configuration to use a centralized `NAV_LINKS` array, improving maintainability and consistency across the application. Navigation links and dashboard cards are now generated dynamically from this shared configuration, reducing duplication and making it easier to update or add new links in the future.

**Navigation and Dashboard Configuration Refactor:**

* Introduced a new `NAV_LINKS` array in `src/config/navLinks.tsx` that defines all navigation links, their icons, routes, descriptions, and colors.
* Updated the sidebar navigation in `AppLayout` to generate its items from `NAV_LINKS`, filtering out the "Settings" link. This replaces the previous hardcoded array of links.
* Updated the dashboard cards in `DashboardPage` to be generated dynamically from `NAV_LINKS`, filtering out "Dashboard" and "Settings" entries. This replaces the previously hardcoded cards. [[1]](diffhunk://#diff-295002f4045a5d68787110b7bf258abdc844ca9441f43ba6aac95a7c741270bfL2-R2) [[2]](diffhunk://#diff-295002f4045a5d68787110b7bf258abdc844ca9441f43ba6aac95a7c741270bfR17-R28)

**UI and Layout Adjustments:**

* Adjusted the sidebar width to be responsive and increased the burger menu size for better usability in `AppLayout`.