### PR TITLE
feat: Add legal pages (Privacy, Terms, Refund) and a marketing footer…

### DIFF
--- a/src/app/(public)/layout.tsx
+++ b/src/app/(public)/layout.tsx
@@ -1,5 +1,6 @@
 
 import { MarketingHeader } from '@/components/MarketingHeader';
+import { MarketingFooter } from '@/components/MarketingFooter';
 import { FloatingThemeToggle } from '@/components/FloatingThemeToggle';
 import { Analytics } from "@vercel/analytics/next"
 
@@ -9,16 +10,14 @@ export default function Layout({
     children: React.ReactNode;
 }) {
     return (
-        <>
+        <div style={{ display: 'flex', flexDirection: 'column', minHeight: '100vh' }}>
             <Analytics />
             <MarketingHeader />
-            <main>
+            <main style={{ flex: 1 }}>
                 {children}
             </main>
-            <footer style={{ padding: '2rem', textAlign: 'center', color: 'var(--mantine-color-dimmed)', fontSize: '0.75rem' }}>
-                &copy; {new Date().getFullYear()} Feldenserra. All rights reserved.
-            </footer>
+            <MarketingFooter />
             <FloatingThemeToggle />
-        </>
+        </div>
     );
 }

--- a/src/app/(public)/legal/privacy/page.tsx
+++ b/src/app/(public)/legal/privacy/page.tsx
@@ -1,0 +1,230 @@
+'use client';
+
+import { Container, Title, Text, Stack, Divider, List, Anchor, Table } from '@mantine/core';
+
+export default function PrivacyPolicyPage() {
+    const lastUpdated = 'January 31, 2026';
+    const version = '1.1';
+    const contactEmail = 'feldenserra@proton.me';
+
+    return (
+        <Container size="md" py="xl">
+            <Stack gap="lg">
+                <div>
+                    <Title order={1}>Privacy Policy</Title>
+                    <Text c="dimmed" size="sm" mt="xs">Last Updated: {lastUpdated} | Version: {version}</Text>
+                </div>
+
+                <Text>
+                    HomeCoreOS (&quot;we&quot;, &quot;our&quot;, or &quot;us&quot;) respects your privacy and is committed to protecting your personal data. This Privacy Policy explains how we collect, use, and safeguard your information when you use our service.
+                </Text>
+
+                <Divider />
+
+                <section>
+                    <Title order={2} size="h3" mb="sm">1. Information We Collect</Title>
+                    <Text mb="sm">
+                        We collect information that you provide directly to us when using HomeCoreOS:
+                    </Text>
+                    <Title order={3} size="h4" mb="xs" mt="md">Account Information</Title>
+                    <List>
+                        <List.Item>Email address</List.Item>
+                        <List.Item>Name (if provided)</List.Item>
+                        <List.Item>Account preferences and settings</List.Item>
+                    </List>
+                    <Title order={3} size="h4" mb="xs" mt="md">User Content</Title>
+                    <List>
+                        <List.Item>Recipes and cooking notes</List.Item>
+                        <List.Item>Tasks and to-do items</List.Item>
+                        <List.Item>Meal plans and schedules</List.Item>
+                        <List.Item>Any other content you create within the app</List.Item>
+                    </List>
+                    <Title order={3} size="h4" mb="xs" mt="md">Usage Information</Title>
+                    <List>
+                        <List.Item>Log data (IP address, browser type, access times)</List.Item>
+                        <List.Item>Device information</List.Item>
+                        <List.Item>Pages visited and features used</List.Item>
+                    </List>
+                </section>
+
+                <section>
+                    <Title order={2} size="h3" mb="sm">2. How We Use Your Information</Title>
+                    <Text mb="sm">
+                        We use the information we collect to:
+                    </Text>
+                    <List>
+                        <List.Item>Provide, maintain, and improve HomeCoreOS</List.Item>
+                        <List.Item>Process your subscription and payments</List.Item>
+                        <List.Item>Send you important updates about the service</List.Item>
+                        <List.Item>Respond to your questions and support requests</List.Item>
+                        <List.Item>Monitor and analyze usage patterns to improve user experience</List.Item>
+                        <List.Item>Protect against fraud and unauthorized access</List.Item>
+                    </List>
+                </section>
+
+                <section>
+                    <Title order={2} size="h3" mb="sm">3. Legal Basis for Processing (EU/EEA Users)</Title>
+                    <Text mb="sm">
+                        For users in the European Union or European Economic Area, we process your personal data based on the following legal grounds:
+                    </Text>
+                    <List>
+                        <List.Item><strong>Contract:</strong> To provide our service to you pursuant to our Terms of Service</List.Item>
+                        <List.Item><strong>Legitimate Interests:</strong> To improve our service, ensure security, and prevent fraud</List.Item>
+                        <List.Item><strong>Consent:</strong> For marketing communications (where applicable)</List.Item>
+                        <List.Item><strong>Legal Obligation:</strong> To comply with applicable laws and regulations</List.Item>
+                    </List>
+                </section>
+
+                <section>
+                    <Title order={2} size="h3" mb="sm">4. Data Sharing</Title>
+                    <Text fw={600} mb="xs">We do not sell your personal data.</Text>
+                    <Text mb="sm">
+                        We only share your information with third parties in the following circumstances:
+                    </Text>
+                    <List>
+                        <List.Item><strong>Service Providers:</strong> We use trusted third-party services to operate HomeCoreOS (see Section 5)</List.Item>
+                        <List.Item><strong>Legal Requirements:</strong> We may disclose information if required by law, subpoena, or court order, or to protect our legal rights</List.Item>
+                        <List.Item><strong>Business Transfers:</strong> In the event of a merger, acquisition, or sale of assets, your data may be transferred to the new entity with notice provided to you</List.Item>
+                    </List>
+                </section>
+
+                <section>
+                    <Title order={2} size="h3" mb="sm">5. Third-Party Services</Title>
+                    <Text mb="sm">
+                        We use the following third-party services to provide HomeCoreOS:
+                    </Text>
+                    <Table mb="sm">
+                        <Table.Thead>
+                            <Table.Tr>
+                                <Table.Th>Service</Table.Th>
+                                <Table.Th>Purpose</Table.Th>
+                                <Table.Th>Privacy Policy</Table.Th>
+                            </Table.Tr>
+                        </Table.Thead>
+                        <Table.Tbody>
+                            <Table.Tr>
+                                <Table.Td>Supabase</Table.Td>
+                                <Table.Td>Database, authentication, and storage</Table.Td>
+                                <Table.Td><Anchor href="https://supabase.com/privacy" target="_blank">View Policy</Anchor></Table.Td>
+                            </Table.Tr>
+                            <Table.Tr>
+                                <Table.Td>Paddle</Table.Td>
+                                <Table.Td>Payment processing (Merchant of Record)</Table.Td>
+                                <Table.Td><Anchor href="https://www.paddle.com/legal/privacy" target="_blank">View Policy</Anchor></Table.Td>
+                            </Table.Tr>
+                            <Table.Tr>
+                                <Table.Td>Vercel</Table.Td>
+                                <Table.Td>Web hosting and analytics</Table.Td>
+                                <Table.Td><Anchor href="https://vercel.com/legal/privacy-policy" target="_blank">View Policy</Anchor></Table.Td>
+                            </Table.Tr>
+                        </Table.Tbody>
+                    </Table>
+                    <Text size="sm" c="dimmed">
+                        These services have their own privacy policies governing their use of your data. We require our service providers to protect your data consistent with this policy.
+                    </Text>
+                </section>
+
+                <section>
+                    <Title order={2} size="h3" mb="sm">6. International Data Transfers</Title>
+                    <Text>
+                        Your information may be transferred to and processed in countries other than your country of residence, including the United States. These countries may have different data protection laws than your country. By using HomeCoreOS, you consent to such transfers. We ensure appropriate safeguards are in place with our service providers to protect your data in compliance with applicable law.
+                    </Text>
+                </section>
+
+                <section>
+                    <Title order={2} size="h3" mb="sm">7. Data Security</Title>
+                    <Text>
+                        We implement appropriate technical and organizational measures to protect your personal data against unauthorized access, alteration, disclosure, or destruction. These measures include encryption in transit and at rest, secure authentication, and regular security assessments. However, no method of transmission over the Internet is 100% secure, and we cannot guarantee absolute security.
+                    </Text>
+                </section>
+
+                <section>
+                    <Title order={2} size="h3" mb="sm">8. Data Retention</Title>
+                    <Text>
+                        We retain your personal data for as long as your account is active or as needed to provide you services. If you delete your account, we will delete your personal data within 30 days, except where we are required to retain it for legal, tax, or regulatory purposes. Anonymized or aggregated data may be retained indefinitely for analytics purposes.
+                    </Text>
+                </section>
+
+                <section>
+                    <Title order={2} size="h3" mb="sm">9. Your Rights</Title>
+                    <Text mb="sm">
+                        Depending on your location, you may have the following rights regarding your personal data:
+                    </Text>
+                    <List>
+                        <List.Item><strong>Access:</strong> Request a copy of your personal data</List.Item>
+                        <List.Item><strong>Correction:</strong> Request correction of inaccurate data</List.Item>
+                        <List.Item><strong>Deletion:</strong> Request deletion of your personal data</List.Item>
+                        <List.Item><strong>Export:</strong> Request your data in a portable format</List.Item>
+                        <List.Item><strong>Restriction:</strong> Request restriction of processing in certain circumstances</List.Item>
+                        <List.Item><strong>Objection:</strong> Object to processing based on legitimate interests</List.Item>
+                        <List.Item><strong>Opt-out:</strong> Opt out of marketing communications</List.Item>
+                    </List>
+                    <Text mt="sm">
+                        To exercise any of these rights, please contact us at{' '}
+                        <Anchor href={`mailto:${contactEmail}`}>{contactEmail}</Anchor>. We will respond to your request within 30 days.
+                    </Text>
+                </section>
+
+                <section>
+                    <Title order={2} size="h3" mb="sm">10. California Privacy Rights (CCPA)</Title>
+                    <Text mb="sm">
+                        If you are a California resident, you have additional rights under the California Consumer Privacy Act (CCPA):
+                    </Text>
+                    <List>
+                        <List.Item><strong>Right to Know:</strong> Request disclosure of personal information we collected, used, and disclosed about you</List.Item>
+                        <List.Item><strong>Right to Delete:</strong> Request deletion of your personal information, subject to certain exceptions</List.Item>
+                        <List.Item><strong>Right to Opt-Out:</strong> Opt out of the sale of personal information (note: we do not sell your personal information)</List.Item>
+                        <List.Item><strong>Right to Non-Discrimination:</strong> Exercise your rights without discriminatory treatment</List.Item>
+                    </List>
+                    <Text mt="sm">
+                        To exercise your California privacy rights, contact us at{' '}
+                        <Anchor href={`mailto:${contactEmail}`}>{contactEmail}</Anchor>.
+                    </Text>
+                </section>
+
+                <section>
+                    <Title order={2} size="h3" mb="sm">11. Cookies and Tracking</Title>
+                    <Text mb="sm">
+                        We use the following types of cookies:
+                    </Text>
+                    <List>
+                        <List.Item><strong>Essential Cookies:</strong> Required for authentication, session management, and core functionality. These cannot be disabled.</List.Item>
+                        <List.Item><strong>Analytics Cookies:</strong> Vercel Analytics collects anonymized usage data to help us understand how users interact with our service.</List.Item>
+                    </List>
+                    <Text mt="sm">
+                        You can control non-essential cookies through your browser settings. Disabling essential cookies may prevent you from using the service properly.
+                    </Text>
+                </section>
+
+                <section>
+                    <Title order={2} size="h3" mb="sm">12. Children&apos;s Privacy</Title>
+                    <Text>
+                        HomeCoreOS is not intended for children under 13 years of age (or 16 in the EEA). We do not knowingly collect personal data from children under these ages. If you believe we have collected data from a child, please contact us immediately and we will promptly delete such information.
+                    </Text>
+                </section>
+
+                <section>
+                    <Title order={2} size="h3" mb="sm">13. Changes to This Policy</Title>
+                    <Text>
+                        We may update this Privacy Policy from time to time. We will notify you of material changes via email or through a prominent notice on the service at least 30 days before the changes take effect. Your continued use of HomeCoreOS after changes constitutes acceptance of the updated policy. We encourage you to review this policy periodically.
+                    </Text>
+                </section>
+
+                <section>
+                    <Title order={2} size="h3" mb="sm">14. Governing Law</Title>
+                    <Text>
+                        This Privacy Policy shall be governed by and construed in accordance with the laws of the State of Nevada, United States, without regard to its conflict of law provisions.
+                    </Text>
+                </section>
+
+                <section>
+                    <Title order={2} size="h3" mb="sm">15. Contact Us</Title>
+                    <Text>
+                        If you have any questions about this Privacy Policy, our data practices, or wish to exercise your privacy rights, please contact us at{' '}
+                        <Anchor href={`mailto:${contactEmail}`}>{contactEmail}</Anchor>.
+                    </Text>
+                </section>
+            </Stack>
+        </Container>
+    );
+}

--- a/src/app/(public)/legal/refund/page.tsx
+++ b/src/app/(public)/legal/refund/page.tsx
@@ -1,0 +1,163 @@
+'use client';
+
+import { Container, Title, Text, Stack, Divider, List, Anchor, Alert } from '@mantine/core';
+import { IconInfoCircle, IconAlertTriangle } from '@tabler/icons-react';
+
+export default function RefundPolicyPage() {
+    const lastUpdated = 'January 31, 2026';
+    const version = '1.1';
+    const contactEmail = 'feldenserra@proton.me';
+
+    return (
+        <Container size="md" py="xl">
+            <Stack gap="lg">
+                <div>
+                    <Title order={1}>Refund Policy</Title>
+                    <Text c="dimmed" size="sm" mt="xs">Last Updated: {lastUpdated} | Version: {version}</Text>
+                </div>
+
+                <Text>
+                    Thank you for subscribing to HomeCoreOS. Please read our refund policy carefully before making a purchase.
+                </Text>
+
+                <Divider />
+
+                <section>
+                    <Title order={2} size="h3" mb="sm">1. Free Trial</Title>
+                    <Text>
+                        HomeCoreOS offers a <strong>7-day free trial</strong> for all new users. During this period, you have full access to all features at no cost. We encourage you to thoroughly explore the service during your trial to ensure it meets your needs.
+                    </Text>
+                    <Alert icon={<IconInfoCircle size={16} />} color="blue" mt="md">
+                        Your subscription will automatically begin and your payment method will be charged at the end of the trial period unless you cancel before the trial ends.
+                    </Alert>
+                </section>
+
+                <section>
+                    <Title order={2} size="h3" mb="sm">2. Subscription Terms</Title>
+                    <List>
+                        <List.Item>HomeCoreOS is billed at <strong>$6.99 per month</strong> (plus applicable taxes)</List.Item>
+                        <List.Item>Subscriptions automatically renew each month on the same day you originally subscribed</List.Item>
+                        <List.Item>You may cancel your subscription at any time through your account settings</List.Item>
+                        <List.Item>Price changes will be communicated at least 30 days in advance</List.Item>
+                    </List>
+                </section>
+
+                <section>
+                    <Title order={2} size="h3" mb="sm">3. Payment Authorization</Title>
+                    <Text>
+                        By providing a payment method and subscribing to HomeCoreOS, you authorize us (through our payment processor, Paddle) to charge your payment method for the subscription fee plus applicable taxes on a recurring monthly basis until you cancel. You are responsible for keeping your payment information current.
+                    </Text>
+                </section>
+
+                <section>
+                    <Title order={2} size="h3" mb="sm">4. No Refunds Policy</Title>
+                    <Alert icon={<IconInfoCircle size={16} />} color="blue" mb="md">
+                        All subscription payments are final and non-refundable.
+                    </Alert>
+                    <Text mb="sm">
+                        Due to the digital nature of our service and the immediate access provided upon payment:
+                    </Text>
+                    <List>
+                        <List.Item>We do not offer refunds for any subscription payments</List.Item>
+                        <List.Item>Partial refunds for unused portions of a billing period are not available</List.Item>
+                        <List.Item>This applies to both monthly renewals and any other charges</List.Item>
+                        <List.Item>Failure to use the service does not entitle you to a refund</List.Item>
+                    </List>
+                    <Text mt="sm" size="sm" c="dimmed">
+                        This policy exists because digital services cannot be &quot;returned&quot; once access has been provided.
+                    </Text>
+                </section>
+
+                <section>
+                    <Title order={2} size="h3" mb="sm">5. Cancellation</Title>
+                    <Text mb="sm">
+                        When you cancel your subscription:
+                    </Text>
+                    <List>
+                        <List.Item>You will retain full access to HomeCoreOS until the end of your current billing period</List.Item>
+                        <List.Item>No further charges will be made after cancellation takes effect</List.Item>
+                        <List.Item>Cancellation does not entitle you to a refund for the current billing period</List.Item>
+                        <List.Item>Your data will be retained for 30 days after your subscription ends, after which it may be permanently deleted</List.Item>
+                        <List.Item>You may reactivate your subscription at any time before your data is deleted</List.Item>
+                    </List>
+                    <Text mt="sm">
+                        To cancel your subscription, go to your account settings or contact us at{' '}
+                        <Anchor href={`mailto:${contactEmail}`}>{contactEmail}</Anchor>.
+                    </Text>
+                </section>
+
+                <section>
+                    <Title order={2} size="h3" mb="sm">6. Exceptional Circumstances</Title>
+                    <Text>
+                        While our standard policy is no refunds, we may consider exceptions solely at our discretion in cases of:
+                    </Text>
+                    <List>
+                        <List.Item>Duplicate charges due to documented technical errors on our end</List.Item>
+                        <List.Item>Extended service outages (exceeding 72 consecutive hours) that significantly impacted your use</List.Item>
+                        <List.Item>Billing errors that resulted in incorrect charges</List.Item>
+                        <List.Item>Other extraordinary circumstances as determined by HomeCoreOS in its sole discretion</List.Item>
+                    </List>
+                    <Text mt="sm">
+                        If you believe you qualify for an exception, please contact us within 30 days of the charge with details of your situation. We will review your request but are under no obligation to grant exceptions.
+                    </Text>
+                </section>
+
+                <section>
+                    <Title order={2} size="h3" mb="sm">7. Payment Disputes & Chargebacks</Title>
+                    <Text mb="sm">
+                        If you have concerns about a charge, please contact us at{' '}
+                        <Anchor href={`mailto:${contactEmail}`}>{contactEmail}</Anchor>{' '}
+                        <strong>before</strong> initiating a dispute with your bank or payment provider. We are happy to review any billing concerns and work towards a resolution.
+                    </Text>
+                    <Alert icon={<IconAlertTriangle size={16} />} color="yellow" mt="md" mb="md">
+                        <Text fw={600} mb="xs">Unauthorized Chargebacks</Text>
+                        <Text size="sm">
+                            If you initiate a chargeback or payment dispute with your bank without first attempting to resolve the issue with us, or if a chargeback is filed fraudulently:
+                        </Text>
+                    </Alert>
+                    <List>
+                        <List.Item>Your account will be immediately terminated and access to the service revoked</List.Item>
+                        <List.Item>We reserve the right to recover the disputed amount plus any chargeback fees through collection efforts</List.Item>
+                        <List.Item>We may report the incident to fraud prevention databases and services</List.Item>
+                        <List.Item>Any outstanding balances will remain your responsibility</List.Item>
+                        <List.Item>You may be prohibited from creating future accounts</List.Item>
+                    </List>
+                    <Text mt="sm" size="sm" c="dimmed">
+                        Fraudulent chargebacks (where you received and used the service but claimed otherwise) may be considered theft of services and may result in legal action.
+                    </Text>
+                </section>
+
+                <section>
+                    <Title order={2} size="h3" mb="sm">8. Payment Processing</Title>
+                    <Text>
+                        Payments are processed by Paddle, our Merchant of Record. By making a purchase, you also agree to Paddle&apos;s{' '}
+                        <Anchor href="https://www.paddle.com/legal/terms" target="_blank">Terms of Service</Anchor> and{' '}
+                        <Anchor href="https://www.paddle.com/legal/privacy" target="_blank">Privacy Policy</Anchor>. Paddle handles all payment processing, invoicing, sales tax, and may require additional verification for fraud prevention purposes. Any payment-related inquiries may be directed to Paddle or to us.
+                    </Text>
+                </section>
+
+                <section>
+                    <Title order={2} size="h3" mb="sm">9. Currency and Taxes</Title>
+                    <Text>
+                        All prices are displayed in USD. Applicable sales tax, VAT, or other taxes will be added based on your location as determined by Paddle. The final charge to your payment method may vary due to currency conversion fees charged by your bank or payment provider, which are not within our control.
+                    </Text>
+                </section>
+
+                <section>
+                    <Title order={2} size="h3" mb="sm">10. Changes to This Policy</Title>
+                    <Text>
+                        We reserve the right to modify this Refund Policy at any time. Material changes will be communicated via email or through the service at least 30 days before taking effect. Your continued use of HomeCoreOS after changes constitutes acceptance of the updated policy.
+                    </Text>
+                </section>
+
+                <section>
+                    <Title order={2} size="h3" mb="sm">11. Contact Us</Title>
+                    <Text>
+                        If you have any questions about our refund policy or need assistance with billing, please contact us at{' '}
+                        <Anchor href={`mailto:${contactEmail}`}>{contactEmail}</Anchor>. We aim to respond to all inquiries within 2 business days.
+                    </Text>
+                </section>
+            </Stack>
+        </Container>
+    );
+}

--- a/src/app/(public)/legal/terms/page.tsx
+++ b/src/app/(public)/legal/terms/page.tsx
@@ -1,0 +1,221 @@
+'use client';
+
+import { Container, Title, Text, Stack, Divider, List, Anchor } from '@mantine/core';
+
+export default function TermsOfServicePage() {
+    const lastUpdated = 'January 31, 2026';
+    const version = '1.1';
+    const contactEmail = 'feldenserra@proton.me';
+
+    return (
+        <Container size="md" py="xl">
+            <Stack gap="lg">
+                <div>
+                    <Title order={1}>Terms of Service</Title>
+                    <Text c="dimmed" size="sm" mt="xs">Last Updated: {lastUpdated} | Version: {version}</Text>
+                </div>
+
+                <Text>
+                    Welcome to HomeCoreOS. By accessing or using our service, you agree to be bound by these Terms of Service (&quot;Terms&quot;). Please read them carefully.
+                </Text>
+
+                <Divider />
+
+                <section>
+                    <Title order={2} size="h3" mb="sm">1. Acceptance of Terms</Title>
+                    <Text>
+                        By creating an account or using HomeCoreOS, you agree to these Terms, our <Anchor href="/legal/privacy">Privacy Policy</Anchor>, and our <Anchor href="/legal/refund">Refund Policy</Anchor>. If you do not agree to these Terms, you may not use our service.
+                    </Text>
+                </section>
+
+                <section>
+                    <Title order={2} size="h3" mb="sm">2. Eligibility</Title>
+                    <Text>
+                        You must be at least 18 years old (or the age of majority in your jurisdiction, whichever is greater) to use HomeCoreOS. By using the service, you represent and warrant that you meet this age requirement and have the legal capacity to enter into these Terms.
+                    </Text>
+                </section>
+
+                <section>
+                    <Title order={2} size="h3" mb="sm">3. Description of Service</Title>
+                    <Text>
+                        HomeCoreOS is a home management application that helps users organize tasks, recipes, and other household activities. We reserve the right to modify, suspend, or discontinue any aspect of the service at any time, with or without notice. We shall not be liable to you or any third party for any modification, suspension, or discontinuation of the service.
+                    </Text>
+                </section>
+
+                <section>
+                    <Title order={2} size="h3" mb="sm">4. Account Registration</Title>
+                    <Text mb="sm">
+                        To use HomeCoreOS, you must create an account. You agree to:
+                    </Text>
+                    <List>
+                        <List.Item>Provide accurate and complete information during registration</List.Item>
+                        <List.Item>Maintain the security of your account credentials and not share them with others</List.Item>
+                        <List.Item>Promptly notify us of any unauthorized use of your account</List.Item>
+                        <List.Item>Be solely responsible for all activities that occur under your account</List.Item>
+                        <List.Item>Not create multiple accounts or accounts on behalf of others without authorization</List.Item>
+                    </List>
+                </section>
+
+                <section>
+                    <Title order={2} size="h3" mb="sm">5. Subscription and Payment</Title>
+                    <Text mb="sm">
+                        HomeCoreOS is offered as a subscription service:
+                    </Text>
+                    <List>
+                        <List.Item>The subscription fee is $6.99 per month (plus applicable taxes)</List.Item>
+                        <List.Item>New users receive a 7-day free trial; your payment method will be charged at the end of the trial unless you cancel</List.Item>
+                        <List.Item>Subscriptions automatically renew each month unless cancelled</List.Item>
+                        <List.Item>You may cancel your subscription at any time through your account settings</List.Item>
+                        <List.Item>Upon cancellation, you retain access until the end of your current billing period</List.Item>
+                        <List.Item>Payments are processed through Paddle, our Merchant of Record</List.Item>
+                    </List>
+                    <Text mt="sm">
+                        Please refer to our <Anchor href="/legal/refund">Refund Policy</Anchor> for information about refunds.
+                    </Text>
+                </section>
+
+                <section>
+                    <Title order={2} size="h3" mb="sm">6. Acceptable Use</Title>
+                    <Text mb="sm">
+                        You agree not to:
+                    </Text>
+                    <List>
+                        <List.Item>Use the service for any unlawful purpose or in violation of any applicable laws</List.Item>
+                        <List.Item>Attempt to gain unauthorized access to our systems, servers, or networks</List.Item>
+                        <List.Item>Interfere with or disrupt the service or servers connected to the service</List.Item>
+                        <List.Item>Upload malicious code, viruses, or any harmful content</List.Item>
+                        <List.Item>Resell, redistribute, or commercially exploit the service without authorization</List.Item>
+                        <List.Item>Use the service to harass, abuse, defame, or harm others</List.Item>
+                        <List.Item>Reverse engineer, decompile, or disassemble any part of the service</List.Item>
+                        <List.Item>Use automated systems (bots, scrapers) to access the service without permission</List.Item>
+                    </List>
+                </section>
+
+                <section>
+                    <Title order={2} size="h3" mb="sm">7. Intellectual Property</Title>
+                    <Text>
+                        HomeCoreOS and its original content, features, functionality, design, logos, and trademarks are owned by HomeCoreOS and are protected by copyright, trademark, patent, trade secret, and other intellectual property laws. You may not copy, modify, distribute, sell, or lease any part of our service or software without our express written permission. You retain ownership of any content you create within the service.
+                    </Text>
+                </section>
+
+                <section>
+                    <Title order={2} size="h3" mb="sm">8. User Content</Title>
+                    <Text>
+                        You retain all rights to the content you create, upload, or store through HomeCoreOS (such as recipes, tasks, and notes). By using the service, you grant us a limited, non-exclusive, royalty-free license to store, process, display, and transmit your content solely to provide and improve the service to you. We will not use your content for advertising or share it publicly without your consent.
+                    </Text>
+                </section>
+
+                <section>
+                    <Title order={2} size="h3" mb="sm">9. Disclaimer of Warranties</Title>
+                    <Text>
+                        THE SERVICE IS PROVIDED &quot;AS IS&quot; AND &quot;AS AVAILABLE&quot; WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO IMPLIED WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, TITLE, AND NON-INFRINGEMENT. WE DO NOT WARRANT THAT THE SERVICE WILL BE UNINTERRUPTED, ERROR-FREE, SECURE, OR FREE OF VIRUSES OR OTHER HARMFUL COMPONENTS. YOUR USE OF THE SERVICE IS AT YOUR OWN RISK. NO ADVICE OR INFORMATION OBTAINED FROM US SHALL CREATE ANY WARRANTY NOT EXPRESSLY STATED HEREIN.
+                    </Text>
+                </section>
+
+                <section>
+                    <Title order={2} size="h3" mb="sm">10. Limitation of Liability</Title>
+                    <Text mb="sm">
+                        TO THE MAXIMUM EXTENT PERMITTED BY APPLICABLE LAW, HOMECOREOS AND ITS OWNERS, OPERATORS, OFFICERS, DIRECTORS, EMPLOYEES, AND AGENTS SHALL NOT BE LIABLE FOR ANY INDIRECT, INCIDENTAL, SPECIAL, CONSEQUENTIAL, EXEMPLARY, OR PUNITIVE DAMAGES, INCLUDING BUT NOT LIMITED TO LOSS OF PROFITS, REVENUES, DATA, USE, GOODWILL, OR OTHER INTANGIBLE LOSSES, RESULTING FROM:
+                    </Text>
+                    <List>
+                        <List.Item>Your use or inability to use the service</List.Item>
+                        <List.Item>Any unauthorized access to or alteration of your data</List.Item>
+                        <List.Item>Any third-party conduct or content on the service</List.Item>
+                        <List.Item>Any interruption or cessation of the service</List.Item>
+                    </List>
+                    <Text mt="sm" fw={600}>
+                        IN NO EVENT SHALL OUR TOTAL AGGREGATE LIABILITY TO YOU FOR ALL CLAIMS ARISING FROM OR RELATED TO THE SERVICE EXCEED THE GREATER OF (A) THE AMOUNTS YOU PAID TO US IN THE TWELVE (12) MONTHS PRECEDING THE CLAIM, OR (B) ONE HUNDRED DOLLARS ($100 USD).
+                    </Text>
+                    <Text mt="sm" size="sm">
+                        Some jurisdictions do not allow the exclusion or limitation of certain damages, so some of the above limitations may not apply to you.
+                    </Text>
+                </section>
+
+                <section>
+                    <Title order={2} size="h3" mb="sm">11. Indemnification</Title>
+                    <Text>
+                        You agree to defend, indemnify, and hold harmless HomeCoreOS and its owners, operators, officers, directors, employees, contractors, and agents from and against any and all claims, damages, obligations, losses, liabilities, costs, and expenses (including reasonable attorney&apos;s fees) arising from: (a) your use of the service; (b) your violation of these Terms; (c) your violation of any third-party rights, including intellectual property rights; or (d) any content you submit through the service.
+                    </Text>
+                </section>
+
+                <section>
+                    <Title order={2} size="h3" mb="sm">12. Dispute Resolution & Arbitration</Title>
+                    <Title order={3} size="h4" mb="xs" mt="md">Informal Resolution</Title>
+                    <Text>
+                        Before initiating any formal dispute resolution, you agree to first contact us at{' '}
+                        <Anchor href={`mailto:${contactEmail}`}>{contactEmail}</Anchor> to attempt to resolve any dispute informally. We will attempt to resolve the dispute within 60 days.
+                    </Text>
+                    <Title order={3} size="h4" mb="xs" mt="md">Binding Arbitration</Title>
+                    <Text>
+                        If we cannot resolve a dispute informally, any dispute, claim, or controversy arising out of or relating to these Terms or the service (except for claims that may be brought in small claims court) shall be resolved by binding arbitration administered by the American Arbitration Association (&quot;AAA&quot;) under its Consumer Arbitration Rules. The arbitration shall be conducted in English, and the seat of arbitration shall be Clark County, Nevada. The arbitration may be conducted by telephone, video conference, or written submissions, at the arbitrator&apos;s discretion.
+                    </Text>
+                    <Title order={3} size="h4" mb="xs" mt="md">Class Action Waiver</Title>
+                    <Text fw={600}>
+                        YOU AND HOMECOREOS AGREE THAT EACH MAY BRING CLAIMS AGAINST THE OTHER ONLY IN YOUR OR ITS INDIVIDUAL CAPACITY AND NOT AS A PLAINTIFF OR CLASS MEMBER IN ANY PURPORTED CLASS, CONSOLIDATED, OR REPRESENTATIVE ACTION. YOU EXPRESSLY WAIVE ANY RIGHT TO PARTICIPATE IN A CLASS ACTION LAWSUIT OR CLASS-WIDE ARBITRATION AGAINST HOMECOREOS.
+                    </Text>
+                    <Title order={3} size="h4" mb="xs" mt="md">Small Claims Exception</Title>
+                    <Text>
+                        Either party may bring a qualifying claim in small claims court in Clark County, Nevada (or your county of residence if you qualify under local rules), rather than through arbitration.
+                    </Text>
+                </section>
+
+                <section>
+                    <Title order={2} size="h3" mb="sm">13. Termination</Title>
+                    <Text>
+                        We may terminate or suspend your account immediately, without prior notice or liability, for any reason, including but not limited to violations of these Terms, suspected fraudulent activity, or any other reason at our sole discretion. Upon termination, your right to use the service will immediately cease. You may terminate your account at any time by cancelling your subscription and ceasing use of the service. Upon termination, certain provisions of these Terms shall survive, including but not limited to Sections 9-12, 14, and 16-19.
+                    </Text>
+                </section>
+
+                <section>
+                    <Title order={2} size="h3" mb="sm">14. Force Majeure</Title>
+                    <Text>
+                        We shall not be liable for any failure or delay in performance resulting from causes beyond our reasonable control, including but not limited to: acts of God, natural disasters, war, terrorism, civil unrest, labor disputes, government actions, pandemic or epidemic, internet service provider failures, third-party service outages, power outages, or cyberattacks. During such events, our obligations shall be suspended for the duration of the event.
+                    </Text>
+                </section>
+
+                <section>
+                    <Title order={2} size="h3" mb="sm">15. Governing Law</Title>
+                    <Text>
+                        These Terms shall be governed by and construed in accordance with the laws of the State of Nevada, United States, without regard to its conflict of law provisions. You agree to submit to the exclusive jurisdiction of the courts located in Clark County, Nevada for any disputes not subject to arbitration.
+                    </Text>
+                </section>
+
+                <section>
+                    <Title order={2} size="h3" mb="sm">16. Changes to Terms</Title>
+                    <Text>
+                        We reserve the right to modify these Terms at any time. We will provide notice of material changes via email or through a prominent notice on the service at least 30 days before the changes take effect. Your continued use of the service after changes take effect constitutes acceptance of the new Terms. If you do not agree to the modified Terms, you must stop using the service and cancel your subscription.
+                    </Text>
+                </section>
+
+                <section>
+                    <Title order={2} size="h3" mb="sm">17. Severability</Title>
+                    <Text>
+                        If any provision of these Terms is found to be unenforceable or invalid by a court of competent jurisdiction, that provision shall be limited or eliminated to the minimum extent necessary so that these Terms shall otherwise remain in full force and effect and enforceable. The invalidity of any provision shall not affect the validity of the remaining provisions.
+                    </Text>
+                </section>
+
+                <section>
+                    <Title order={2} size="h3" mb="sm">18. Entire Agreement</Title>
+                    <Text>
+                        These Terms, together with our <Anchor href="/legal/privacy">Privacy Policy</Anchor> and <Anchor href="/legal/refund">Refund Policy</Anchor>, constitute the entire agreement between you and HomeCoreOS regarding your use of the service. These Terms supersede all prior agreements, understandings, negotiations, and communications, whether written or oral, between you and HomeCoreOS regarding the subject matter hereof.
+                    </Text>
+                </section>
+
+                <section>
+                    <Title order={2} size="h3" mb="sm">19. Waiver</Title>
+                    <Text>
+                        No waiver of any term of these Terms shall be deemed a further or continuing waiver of such term or any other term. Our failure to assert any right or provision under these Terms shall not constitute a waiver of such right or provision.
+                    </Text>
+                </section>
+
+                <section>
+                    <Title order={2} size="h3" mb="sm">20. Contact Us</Title>
+                    <Text>
+                        If you have any questions about these Terms, please contact us at{' '}
+                        <Anchor href={`mailto:${contactEmail}`}>{contactEmail}</Anchor>.
+                    </Text>
+                </section>
+            </Stack>
+        </Container>
+    );
+}

--- a/src/components/MarketingFooter.tsx
+++ b/src/components/MarketingFooter.tsx
@@ -1,0 +1,44 @@
+'use client';
+
+import { Container, Group, Anchor, Text, Stack, Divider } from '@mantine/core';
+import Link from 'next/link';
+
+const legalLinks = [
+    { label: 'Terms of Service', href: '/legal/terms' },
+    { label: 'Privacy Policy', href: '/legal/privacy' },
+    { label: 'Refund Policy', href: '/legal/refund' },
+];
+
+export function MarketingFooter() {
+    const currentYear = new Date().getFullYear();
+
+    return (
+        <footer style={{
+            marginTop: 'auto',
+            borderTop: '1px solid var(--mantine-color-default-border)',
+            backgroundColor: 'var(--mantine-color-body)'
+        }}>
+            <Container size="lg" py="xl">
+                <Stack gap="md" align="center">
+                    <Group gap="lg" justify="center">
+                        {legalLinks.map((link) => (
+                            <Anchor
+                                key={link.href}
+                                component={Link}
+                                href={link.href}
+                                size="sm"
+                                c="dimmed"
+                            >
+                                {link.label}
+                            </Anchor>
+                        ))}
+                    </Group>
+                    <Divider w="100%" maw={400} />
+                    <Text size="xs" c="dimmed" ta="center">
+                        © {currentYear} HomeCoreOS. All rights reserved.
+                    </Text>
+                </Stack>
+            </Container>
+        </footer>
+    );
+}


### PR DESCRIPTION
This pull request adds new legal policy pages for privacy and refunds, and refactors the public layout to use a shared footer component for consistency. The most important changes are the addition of comprehensive privacy and refund policy pages, and improvements to the layout structure for maintainability and design consistency.

**Legal Policy Pages**

* Added a new, detailed Privacy Policy page in `src/app/(public)/legal/privacy/page.tsx` covering data collection, usage, sharing, third-party services, international transfers, security, retention, user rights (including EU/EEA and California), cookies, children's privacy, and contact information.
* Added a new Refund Policy page in `src/app/(public)/legal/refund/page.tsx` detailing free trial terms, subscription billing, no-refunds policy, cancellation process, exceptional circumstances, chargebacks, payment processing, taxes, and contact information.

**Layout Refactor**

* Updated the public layout in `src/app/(public)/layout.tsx` to use a shared `MarketingFooter` component instead of a hardcoded footer, improving consistency and maintainability across pages. [[1]](diffhunk://#diff-af7b390134df0a564fa9c4ebff2780051c4c0ff6d6546ca3b58278cefd493139R3) [[2]](diffhunk://#diff-af7b390134df0a564fa9c4ebff2780051c4c0ff6d6546ca3b58278cefd493139L12-R21)
* Changed the layout structure to use a flex column with `minHeight: '100vh'` and made `<main>` flex-grow for better vertical alignment and responsive design.