### PR TITLE
feat: add a BackToTop component and integrate it into the public layout.

### DIFF
--- a/src/app/(public)/layout.tsx
+++ b/src/app/(public)/layout.tsx
@@ -2,6 +2,7 @@
 import { MarketingHeader } from '@/components/MarketingHeader';
 import { MarketingFooter } from '@/components/MarketingFooter';
 import { FloatingThemeToggle } from '@/components/FloatingThemeToggle';
+import { BackToTop } from '@/components/BackToTop';
 import { Analytics } from "@vercel/analytics/next"
 
 export default function Layout({
@@ -18,6 +19,7 @@ export default function Layout({
             </main>
             <MarketingFooter />
             <FloatingThemeToggle />
+            <BackToTop />
         </div>
     );
 }

--- a/src/components/BackToTop.tsx
+++ b/src/components/BackToTop.tsx
@@ -1,0 +1,50 @@
+'use client';
+
+import { ActionIcon, Transition } from '@mantine/core';
+import { IconArrowUp } from '@tabler/icons-react';
+import { useEffect, useState } from 'react';
+
+export function BackToTop() {
+    const [isVisible, setIsVisible] = useState(false);
+
+    useEffect(() => {
+        const toggleVisibility = () => {
+            // Show button when page is scrolled down 300px
+            setIsVisible(window.scrollY > 300);
+        };
+
+        window.addEventListener('scroll', toggleVisibility, { passive: true });
+
+        return () => window.removeEventListener('scroll', toggleVisibility);
+    }, []);
+
+    const scrollToTop = () => {
+        window.scrollTo({
+            top: 0,
+            behavior: 'smooth',
+        });
+    };
+
+    return (
+        <Transition transition="slide-up" duration={200} mounted={isVisible}>
+            {(styles) => (
+                <ActionIcon
+                    onClick={scrollToTop}
+                    size="lg"
+                    radius="xl"
+                    variant="default"
+                    aria-label="Back to top"
+                    style={{
+                        ...styles,
+                        position: 'fixed',
+                        bottom: 20,
+                        right: 20,
+                        zIndex: 1000,
+                    }}
+                >
+                    <IconArrowUp size={18} stroke={1.5} />
+                </ActionIcon>
+            )}
+        </Transition>
+    );
+}


### PR DESCRIPTION
This pull request adds a "Back to Top" button to the public layout of the app, improving user experience by allowing quick navigation to the top of the page. The button appears when the user scrolls down and uses smooth scrolling for a polished effect.

**UI/UX Enhancements:**

* Added a new `BackToTop` component that displays a floating button when the user scrolls down 300px, allowing them to smoothly scroll back to the top of the page. (`src/components/BackToTop.tsx`)

* Integrated the `BackToTop` component into the public layout so it appears on all public pages, alongside existing floating UI elements. (`src/app/(public)/layout.tsx`) [[1]](diffhunk://#diff-af7b390134df0a564fa9c4ebff2780051c4c0ff6d6546ca3b58278cefd493139R5) [[2]](diffhunk://#diff-af7b390134df0a564fa9c4ebff2780051c4c0ff6d6546ca3b58278cefd493139R22)